### PR TITLE
Composer version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.6.4",
-        "illuminate/notifications": "^5.3",
-        "illuminate/support": "^5.1|^5.2|^5.3"
+        "illuminate/notifications": "5.3.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
Currently the constraints for `laravel/notifications` and `laravel/support` are using the caret notation which would support a minimum of 5.3, including 5.4 in the future.

Would it not be better to use 5.3.\* considering laravel doesn't follow semver?
