### PR TITLE
Some upgrades!

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.2",
         "illuminate/notifications": "~5.5 || ~6.0",
         "illuminate/support": "~5.5 || ~6.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "illuminate/support": "~5.5 || ~6.0"
     },
     "require-dev": {
-        "mockery/mockery": "^0.9.5",
-        "phpunit/phpunit": "5.*"
+        "mockery/mockery": "^1.0",
+        "phpunit/phpunit": "^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/ExampleTest.php
+++ b/tests/ExampleTest.php
@@ -2,7 +2,9 @@
 
 namespace NotificationChannels\:channel_namespace\Test;
 
-class ExampleTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ExampleTest extends TestCase
 {
     /** @test */
     public function true_is_true()


### PR DESCRIPTION
PHP `7.0` has already reached EOL. `7.1`'s security fixes are until Dec 2019 only. While `7.4` is around the corner, I think the min. we should consider now is `7.2` which is good enough for quite some time and in sync with Laravel as well.

I would also suggest we consider dropping Laravel `5.5` entirely and have new packages be Laravel 6 supported only. Thoughts?